### PR TITLE
fix: actually handle errors in get_data_safe

### DIFF
--- a/scripts/ch_lib/util.py
+++ b/scripts/ch_lib/util.py
@@ -87,9 +87,8 @@ def get_subfolders(folder:str) -> list:
 
 
 def get_data_safe(data, key, default_value):
-    return data[key]
     try:
-        return data[key]
+        return get(data, key, default_value)
     except:
         return default_value
 


### PR DESCRIPTION
I encountered the following error several times today on my first ever time running the "Scan Models for Civitai" functionality in the a1111 UI for this extension. 

```
Civitai Helper: Request model info from civitai
Civitai Helper: Civitai does not have this model
Civitai Helper: Write model info to file: /home/username/stable-diffusion-webui/models/Lora/modelname.civitai.info
Traceback (most recent call last):

...

  File "/home/username/stable-diffusion-webui/extensions/Stable-Diffusion-Webui-Civitai-Helper/scripts/ch_lib/model_action_civitai.py", line 82, in scan_model
    write_sd15_model_info(sd15_file, model_info)
  File "/home/username/stable-diffusion-webui/extensions/Stable-Diffusion-Webui-Civitai-Helper/scripts/ch_lib/model_action_civitai.py", line 118, in write_sd15_model_info
    data["description"] = get_data_safe(model_info, "description", "")
  File "/home/username/stable-diffusion-webui/extensions/Stable-Diffusion-Webui-Civitai-Helper/scripts/ch_lib/util.py", line 90, in get_data_safe
    return data[key]
KeyError: 'description'
```

At the time this exception was raised, the `modelname.civitai.info` file contained only `{}`. I discovered that I could manually "fix" the file by replacing it with `{"description":""}` and restarting scan would handle the file just fine, but then it choked on another file later that also contained only `{}` that I would have to manually fix. (Probably several more after that.) Note that this didn't happen for all models. I'm not sure why some got an empty `{}` while others worked just fine, but I didn't want to chase down _that_ problem too. 🙂 

So, this PR fixes `get_data_safe` so that it _actually_ handles `KeyError` or any other exception. I'm not a fan of the unspecified `except`, but I think I implemented whatever the original author _intended_ this function to do, and that's good enough for now.

I was able to successfully complete "Scan Models for Civitai" without errors after making this change.

```
Civitai Helper: Done. Scanned 202 models, checked 202 images
```
👍 