### PR TITLE
增加civitai元数据示例图图片生成信息功能，并将生成信息按照civitai.info的格式保存到meta中

### DIFF
--- a/scripts/ch_lib/model.py
+++ b/scripts/ch_lib/model.py
@@ -100,10 +100,9 @@ def metadata_needed(info_file, sd15_file, refetch_old):
     """
 
     need_civitai = metadata_needed_for_type(info_file, "civitai", refetch_old)
-    #need_sdwebui = metadata_needed_for_type(sd15_file, "sdwebui", refetch_old)
+    need_sdwebui = metadata_needed_for_type(sd15_file, "sdwebui", refetch_old)
 
-    return need_civitai# or need_sdwebui
-
+    return need_civitai or need_sdwebui
 
 
 def metadata_needed_for_type(path, meta_type, refetch_old):
@@ -211,9 +210,6 @@ def process_model_info(model_path, model_info, model_type="ckp", refetch_old=Fal
         version_description = util.trim_html(version_description)
     model_info["description"] = version_description
 
-    import re
-    model_info["description"] = re.sub(r'[<>]', "", model_info["description"] + parent["description"])
-
     tags = parent.get("tags", [])
     parent["tags"] = tags
 
@@ -314,11 +310,11 @@ def process_sd15_info(sd15_file, model_info, parent, model_type, refetch_old):
 
     sd_data["extensions"] = util.create_extension_block(sd_data.get("extensions", None))
 
-    #if refetch_old:
-        #if verify_overwrite_eligibility(sd15_file, sd_data):
-            #write_info(sd_data, sd15_file, "webui")
-    #else:
-        #write_info(sd_data, sd15_file, "webui")
+    if refetch_old:
+        if verify_overwrite_eligibility(sd15_file, sd_data):
+            write_info(sd_data, sd15_file, "webui")
+    else:
+        write_info(sd_data, sd15_file, "webui")
 
 
 def load_model_info(path):
@@ -488,7 +484,6 @@ def get_model_path_by_search_term(model_type, search_term):
         return None
 
     return model_path
-
 def sd_format(data):
 	steps_index = data.find("\nSteps:")
 
@@ -602,4 +597,3 @@ def Scan_civitai_info_image_meta():
 	output = f"Done. Scanned {count} images."
 	util.printD(output)
 	return output
-

--- a/scripts/ch_lib/model.py
+++ b/scripts/ch_lib/model.py
@@ -3,11 +3,18 @@ Handle model operations
 """
 import os
 import json
+import glob
+import re
+import requests
+import piexif
+import piexif.helper
 from modules import shared
 from modules import paths_internal
 from modules.shared import opts
 from . import civitai
 from . import util
+from io import BytesIO
+from PIL import Image
 
 
 # this is the default root path
@@ -477,3 +484,113 @@ def get_model_path_by_search_term(model_type, search_term):
         return None
 
     return model_path
+
+def sd_format(data):
+	steps_index = data.find("\nSteps:")
+
+	if steps_index != -1:
+		_prompt = data[:steps_index].strip()
+		_setting = data[steps_index:].strip()
+
+	if "Negative prompt:" in data:
+		prompt_index = data.find("\nNegative prompt:")
+
+		if steps_index != -1:
+			_negative = data[
+				prompt_index + len("Negative prompt:") + 1 : steps_index
+			].strip()
+
+		else:
+			_negative = data[
+				prompt_index + len("Negative prompt:") + 1 :
+			].strip()
+		_prompt = data[:prompt_index].strip()
+
+	elif steps_index == -1:
+		_prompt = data
+
+	string_list = _setting.split(",")
+	pattern = r"\s*([^:,]+):\s*([^,]+)"
+	setting_dict = dict(re.findall(pattern, _setting))
+
+	_Steps = setting_dict.get("Steps")
+	_Sampler = setting_dict.get("Sampler")
+	_CFG_scale = setting_dict.get("CFG scale")
+	_Seed = setting_dict.get("Seed")
+	_Size = setting_dict.get("Size")
+
+
+	return (_prompt,_negative,_Steps,_Sampler,_CFG_scale,_Seed,_Size)
+
+
+def Read_remote_image_info(img_src):
+	response = requests.get(img_src, timeout=(5, 10))
+	files=BytesIO(response.content)
+	with Image.open(files) as f:
+		try:
+			exif = json.loads(f.getexif().get(0x0110))
+		except TypeError:
+			if f.format == "PNG":
+				data=f.info.get("parameters")
+			elif f.format == "JPEG" or f.format == "WEBP":
+				try:
+					exif = piexif.load(f.info.get("exif")) or {}
+					datajpeg = piexif.helper.UserComment.load(
+						exif.get("Exif").get(piexif.ExifIFD.UserComment)
+					)
+					data = datajpeg
+				except Exception:
+					pass
+		try:
+			_prompt,_negative,_Steps,_Sampler,_CFG_scale,_Seed,_Size= sd_format(data)
+			return (_prompt,_negative,_Steps,_Sampler,_CFG_scale,_Seed,_Size)
+		except Exception:
+			print(f"{img_src} not generate information")
+
+def Update_civitai_info_image_meta(file):
+	need_update = False
+	data = {}
+	if os.path.isfile(file):
+		with open(file, 'r') as f:
+			data = json.load(f)
+			f.close()
+		for i, image in enumerate(data.get('images',[])):
+			meta_data = image.get('meta', None)
+			if not meta_data:
+				meta_data = {}
+				try:
+					_prompt,_negative,_Steps,_Sampler,_CFG_scale,_Seed,_Size = Read_remote_image_info(image.get('url',''))
+					meta_data["prompt"] = _prompt
+					meta_data["negative"] = _negative
+					meta_data["Steps"] = _Steps
+					meta_data["Sampler"] = _CFG_scale
+					meta_data["CFG_scale"] = _CFG_scale
+					meta_data["Seed"] = _Seed
+					meta_data["Size"] = _Size
+					image["meta"] = meta_data
+					need_update = True
+				except Exception:
+					print(f"{image.get('url')} is Error")
+	if need_update:
+		with open(file, 'w') as f:
+			json.dump(data, f, indent=4)
+			f.close()
+def Scan_civitai_info_image_meta():
+	util.printD("Start Scan_civitai_info_image_meta")
+	output = ""
+	count = 0
+	embeddings_path = os.path.join(paths_internal.data_path, "embeddings")
+	for root, dirs, files in os.walk(embeddings_path):
+		for file in files:
+			if file.endswith('.civitai.info'):
+				Update_civitai_info_image_meta(os.path.join(root, file))
+				count = count + 1
+	models_path = os.path.join(paths_internal.data_path, "models")
+	for root, dirs, files in os.walk(models_path):
+		for file in files:
+			if file.endswith('.civitai.info'):
+				Update_civitai_info_image_meta(os.path.join(root, file))
+				count = count + 1
+	output = f"Done. Scanned {count} models."
+	util.printD(output)
+	return output

--- a/scripts/ch_lib/model.py
+++ b/scripts/ch_lib/model.py
@@ -100,9 +100,10 @@ def metadata_needed(info_file, sd15_file, refetch_old):
     """
 
     need_civitai = metadata_needed_for_type(info_file, "civitai", refetch_old)
-    need_sdwebui = metadata_needed_for_type(sd15_file, "sdwebui", refetch_old)
+    #need_sdwebui = metadata_needed_for_type(sd15_file, "sdwebui", refetch_old)
 
-    return need_civitai or need_sdwebui
+    return need_civitai# or need_sdwebui
+
 
 
 def metadata_needed_for_type(path, meta_type, refetch_old):
@@ -210,6 +211,9 @@ def process_model_info(model_path, model_info, model_type="ckp", refetch_old=Fal
         version_description = util.trim_html(version_description)
     model_info["description"] = version_description
 
+    import re
+    model_info["description"] = re.sub(r'[<>]', "", model_info["description"] + parent["description"])
+
     tags = parent.get("tags", [])
     parent["tags"] = tags
 
@@ -310,11 +314,11 @@ def process_sd15_info(sd15_file, model_info, parent, model_type, refetch_old):
 
     sd_data["extensions"] = util.create_extension_block(sd_data.get("extensions", None))
 
-    if refetch_old:
-        if verify_overwrite_eligibility(sd15_file, sd_data):
-            write_info(sd_data, sd15_file, "webui")
-    else:
-        write_info(sd_data, sd15_file, "webui")
+    #if refetch_old:
+        #if verify_overwrite_eligibility(sd15_file, sd_data):
+            #write_info(sd_data, sd15_file, "webui")
+    #else:
+        #write_info(sd_data, sd15_file, "webui")
 
 
 def load_model_info(path):
@@ -551,26 +555,30 @@ def Update_civitai_info_image_meta(file):
 	need_update = False
 	data = {}
 	if os.path.isfile(file):
-		with open(file, 'r') as f:
-			data = json.load(f)
-			f.close()
-		for i, image in enumerate(data.get('images',[])):
-			meta_data = image.get('meta', None)
-			if not meta_data:
-				meta_data = {}
-				try:
-					_prompt,_negative,_Steps,_Sampler,_CFG_scale,_Seed,_Size = Read_remote_image_info(image.get('url',''))
-					meta_data["prompt"] = _prompt
-					meta_data["negative"] = _negative
-					meta_data["Steps"] = _Steps
-					meta_data["Sampler"] = _CFG_scale
-					meta_data["CFG_scale"] = _CFG_scale
-					meta_data["Seed"] = _Seed
-					meta_data["Size"] = _Size
-					image["meta"] = meta_data
-					need_update = True
-				except Exception:
-					print(f"{image.get('url')} is Error")
+		try:
+			with open(file, 'r') as f:
+				data = json.load(f)
+				f.close()
+			for i, image in enumerate(data.get('images',[])):
+				meta_data = image.get('meta', None)
+				if not meta_data:
+					meta_data = {}
+					try:
+						_prompt,_negative,_Steps,_Sampler,_CFG_scale,_Seed,_Size = Read_remote_image_info(image.get('url',''))
+						meta_data["prompt"] = _prompt
+						meta_data["negative"] = _negative
+						meta_data["Steps"] = _Steps
+						meta_data["Sampler"] = _CFG_scale
+						meta_data["CFG_scale"] = _CFG_scale
+						meta_data["Seed"] = _Seed
+						meta_data["Size"] = _Size
+						image["meta"] = meta_data
+						need_update = True
+					except Exception:
+						pass
+		except Exception:
+			pass
+			print(f"{file} is Error")
 	if need_update:
 		with open(file, 'w') as f:
 			json.dump(data, f, indent=4)
@@ -591,6 +599,7 @@ def Scan_civitai_info_image_meta():
 			if file.endswith('.civitai.info'):
 				Update_civitai_info_image_meta(os.path.join(root, file))
 				count = count + 1
-	output = f"Done. Scanned {count} models."
+	output = f"Done. Scanned {count} images."
 	util.printD(output)
 	return output
+

--- a/scripts/civitai_helper.py
+++ b/scripts/civitai_helper.py
@@ -138,11 +138,18 @@ def on_ui_tabs():
                             value=model_types
                         )
 
+
                 # with gr.Row():
                 scan_model_civitai_btn = gr.Button(
                     value="Scan",
                     variant="primary",
                     elem_id="ch_scan_model_civitai_btn"
+                )
+
+                Scan_civitai_info_image_meta_btn = gr.Button(
+                    value="Update image generation information(Experimental)",
+                    variant="primary",
+                    elem_id="ch_Scan_civitai_info_image_meta_btn"
                 )
                 # with gr.Row():
                 scan_model_log_md = gr.Markdown(
@@ -328,6 +335,11 @@ def on_ui_tabs():
                 scan_model_types_drop, max_size_preview_ckb,
                 nsfw_preview_threshold_drop, refetch_old_ckb
             ],
+            outputs=scan_model_log_md
+        )
+
+        Scan_civitai_info_image_meta_btn.click(
+            model.Scan_civitai_info_image_meta,
             outputs=scan_model_log_md
         )
 


### PR DESCRIPTION
实现 #17 中提到的功能，结合[sd-model-preview-xd](https://github.com/CurtisDS/sd-model-preview-xd)插件和[lora-prompt-tool](https://github.com/a2569875/lora-prompt-tool)插件可以很方便的将示例图的生成信息加载到webui