### PR TITLE
增加civitai元数据示例图图片生成信息功能，并将生成信息按照civitai.info的格式保存到meta中

### DIFF
--- a/scripts/ch_lib/model.py
+++ b/scripts/ch_lib/model.py
@@ -564,7 +564,7 @@ def Update_civitai_info_image_meta(file):
 				f.close()
 			for i, image in enumerate(data.get('images',[])):
 				meta_data = image.get('meta', None)
-				if not meta_data:
+				if not meta_data and meta_data != {}:
 					print(f"{file} is being updated")
 					meta_data = {}
 					try:
@@ -580,7 +580,7 @@ def Update_civitai_info_image_meta(file):
 							image["meta"] = meta_data
 							need_update = True
 						if _check == 2:
-							image["meta"] = "None"
+							image["meta"] = {}
 							need_update = True
 					except Exception:
 						pass

--- a/scripts/civitai_helper.py
+++ b/scripts/civitai_helper.py
@@ -144,6 +144,13 @@ def on_ui_tabs():
                     variant="primary",
                     elem_id="ch_scan_model_civitai_btn"
                 )
+
+                Scan_civitai_info_image_meta_btn = gr.Button(
+                    value="Update image generation information(Experimental)",
+                    variant="primary",
+                    elem_id="ch_Scan_civitai_info_image_meta_btn"
+                )
+
                 # with gr.Row():
                 scan_model_log_md = gr.Markdown(
                     value="Scanning takes time, just wait. Check console log for detail",
@@ -328,6 +335,11 @@ def on_ui_tabs():
                 scan_model_types_drop, max_size_preview_ckb,
                 nsfw_preview_threshold_drop, refetch_old_ckb
             ],
+            outputs=scan_model_log_md
+        )
+
+        Scan_civitai_info_image_meta_btn.click(
+            model.Scan_civitai_info_image_meta,
             outputs=scan_model_log_md
         )
 


### PR DESCRIPTION
实现 #17 中提到的功能，结合[sd-model-preview-xd](https://github.com/CurtisDS/sd-model-preview-xd)插件和[lora-prompt-tool](https://github.com/a2569875/lora-prompt-tool)插件可以很方便的将示例图的生成信息加载到webui