### PR TITLE
Failsafe because git_tag doesn't exist in vladmandic/automatic

### DIFF
--- a/scripts/ch_lib/model_action_civitai.py
+++ b/scripts/ch_lib/model_action_civitai.py
@@ -174,7 +174,12 @@ def dummy_model_info(path, sha256_hash, model_type):
     # do store their training data.
     trained_words = model_info["trainedWords"]
 
-    file_metadata = sd_models.read_metadata_from_safetensors(path)
+    try:
+        file_metadata = sd_models.read_metadata_from_safetensors(path)
+    except AssertionError:
+        # model is not a safetensors file. This is fine,
+        # it just doesn't have metadata we can read
+        pass
 
     tag_frequency = file_metadata.get("ss_tag_frequency", {})
 

--- a/scripts/ch_lib/util.py
+++ b/scripts/ch_lib/util.py
@@ -430,13 +430,26 @@ def webui_version():
         returns the version in the form 'X.Y.Z'
     '''
     version = None
-    tag = launch.git_tag()
-    match = re.match(r"v([\d.]+)", tag)
-    if match:
-        version = match.group(1)
-    else:
-        # XXX assume a modern SD Webui version if one cannot be found.
-        version = "1.6.0"
+    try:
+        tag = launch.git_tag()
+        match = re.match(r"v([\d.]+)", tag)
+        if match:
+            version = match.group(1)
+        else:
+            # XXX assume a modern SD Webui version if one cannot be found.
+            version = "1.6.0"
+    except AttributeError as e:
+        try:
+            return subprocess.check_output([git, "describe", "--tags"], shell=False, encoding='utf8').strip()
+        except Exception:
+            try:
+                changelog_md = os.path.join(os.path.dirname(os.path.dirname(__file__)), "CHANGELOG.md")
+                with open(changelog_md, "r", encoding="utf-8") as file:
+                    line = next((line.strip() for line in file if line.strip()), "<none>")
+                    line = line.replace("## ", "")
+                    version = line
+            except Exception:
+                version = "1.6.0"
     return version
 
 


### PR DESCRIPTION
Vladmandic's automatic UI doesn't have the launch.git_tag(), so I created a klunky try/except clause manually get the tag version.