### PR TITLE
Fix info and preview downloading for model updates

### DIFF
--- a/scripts/ch_lib/js_action_civitai.py
+++ b/scripts/ch_lib/js_action_civitai.py
@@ -221,7 +221,7 @@ def dl_model_new_version(msg, max_size_preview, nsfw_preview_threshold):
         if isinstance(result, str):
             yield result
             continue
-        success, _ = result
+        success, new_model_path = result
 
     if not success:
         return "Model download failed. See console for more details."
@@ -230,11 +230,11 @@ def dl_model_new_version(msg, max_size_preview, nsfw_preview_threshold):
     version_info = civitai.get_version_info_by_version_id(version_id)
 
     # now write version info to files
-    model.process_model_info(msg, version_info, model_type)
+    model.process_model_info(new_model_path, version_info, model_type)
 
     # then, get preview image
     for result in civitai.get_preview_image_by_model_path(
-        msg,
+        new_model_path,
         max_size_preview,
         nsfw_preview_threshold
     ):

--- a/scripts/ch_lib/js_action_civitai.py
+++ b/scripts/ch_lib/js_action_civitai.py
@@ -240,7 +240,7 @@ def dl_model_new_version(msg, max_size_preview, nsfw_preview_threshold):
     ):
         yield result
 
-    output = f"Done. Model downloaded to: {msg}"
+    output = f"Done. Model downloaded to: {new_model_path}"
     util.printD(output)
     yield output
 


### PR DESCRIPTION
Broken by this line https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper/blame/174d3d977c343336aba8f3164668e708d80c2adf/scripts/ch_lib/js_action_civitai.py#L224 from this commit https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper/commit/63d8d6fd60b88370e6ba828fc81b97dac8af43f5

Capture newly downloaded model file name and pass it to `process_model_info()` and `get_preview_image_by_model_path()` instead of discarding it.