### PR TITLE
Fix bug update_dl_inputs for unhandled_files

### DIFF
--- a/scripts/sections.py
+++ b/scripts/sections.py
@@ -289,9 +289,17 @@ def download_section():
             visible = False
             filename = ""
             if filedata:
-                _, data = filedata
                 visible = True
-                filename = data["name"]
+                if isinstance(filedata, str):
+                    filename = ", ".join([
+                        filedata_str.split(":")[1].strip()
+                        for filedata_str in filedata.split("\n")
+                    ])
+                elif isinstance(filedata, tuple):
+                    _, data = filedata
+                    filename = data["name"]
+                else:
+                    raise ValueError(f"Invalid filedata: {filedata}")
 
             output_add.append(elems["txtbx"].update(value=filename))
             output_add.append(elems["row"].update(visible=visible))


### PR DESCRIPTION
When unhandled_files is not None, it is stored as a string in the function get_model_info_by_url, but update_dl_inputs assumes a tuple when extracting filename, leading to an error.