### PR TITLE
Fix v1.8.3 update checking

### DIFF
--- a/ch_lib/civitai.py
+++ b/ch_lib/civitai.py
@@ -651,16 +651,19 @@ def check_single_model_new_version(root, filename, model_type, delay):
     request = request + (model_type,)
 
     # model_path, model_id, model_name, version_id, new_version_name, description, downloadUrl, img_url = request
-    version_id = request[3]
+    model_ids = {
+        'model': request[1],
+        'version': request[3],
+    }
 
     # check exist
-    if not version_id:
+    if not (model_ids['version'] and model_ids['model']):
         return False
 
     # search this new version id to check if this model is already downloaded
-    target_model_info = search_local_model_info_by_version_id(root, version_id)
+    target_model_info = search_local_model_info_by_version_id(root, model_ids)
     if target_model_info:
-        util.printD("New version is already exists")
+        util.printD("New version already exists")
         return False
 
     return request

--- a/ch_lib/model_action_civitai.py
+++ b/ch_lib/model_action_civitai.py
@@ -361,11 +361,13 @@ def check_models_new_version_to_md(model_types:list) -> str:
 
     articles = []
     count = 0
-    for count, new_version in enumerate(new_versions):
+    for index, new_version in enumerate(new_versions):
         article = build_article_from_version(new_version)
         articles.append(article)
 
     output = f"Found new versions for following models: <section>{''.join(articles)}</section>"
+
+    count = index + 1
 
     if count != 1:
         util.printD(f"Done. Found {count} models that have new versions. Check UI for detail")
@@ -624,7 +626,7 @@ def download_files(filename, model_folder, ver_info, headers, filetypes, dl_all,
     errors_count = 0
     snippet = None
 
-    for count, dl_info in enumerate(downloads):
+    for index, dl_info in enumerate(downloads):
 
         url = dl_info["url"]
         if errors_count > 0:
@@ -643,7 +645,7 @@ def download_files(filename, model_folder, ver_info, headers, filetypes, dl_all,
                 success, output = result
                 break
 
-            output = f"{result} | {count}/{total} files"
+            output = f"{result} | {index+1}/{total} files"
             if snippet:
                 " | ".join([output, snippet])
 


### PR DESCRIPTION
Changes made for batch downloading broke update checking, so I modified check_single_model_new_version to match the updated dict parameter to search_local_model_info_by_version_id.

I also noticed updated model counts were 1 lower than they should be so I modified the two place I saw enumerate() being used as if it returned a count rather than index.