### PR TITLE
Add ability to auto organize loras

### DIFF
--- a/ch_lib/civitai.py
+++ b/ch_lib/civitai.py
@@ -60,7 +60,8 @@ NSFW_LEVELS = {
     # "Blocked": 32,
 }
 
-def civitai_get(civitai_url:str):
+
+def civitai_get(civitai_url: str):
     """
     Gets JSON from Civitai.
     return: dict:json or None
@@ -127,7 +128,7 @@ def append_parent_model_metadata(content):
     return content
 
 
-def get_model_info_by_hash(model_hash:str):
+def get_model_info_by_hash(model_hash: str):
     """
     use this sha256 to get model info from civitai's api
 
@@ -159,7 +160,7 @@ def get_model_info_by_hash(model_hash:str):
     return content
 
 
-def get_model_info_by_id(model_id:str) -> dict:
+def get_model_info_by_id(model_id: str) -> dict:
     """
     Fetches model info by its model id.
     returns: dict:model_info
@@ -176,7 +177,7 @@ def get_model_info_by_id(model_id:str) -> dict:
     return content
 
 
-def get_version_info_by_version_id(version_id:str) -> dict:
+def get_version_info_by_version_id(version_id: str) -> dict:
     """
     Gets model version info from Civitai by version id
     return: dict:model_info
@@ -195,7 +196,7 @@ def get_version_info_by_version_id(version_id:str) -> dict:
     return content
 
 
-def get_version_info_by_model_id(model_id:str) -> dict:
+def get_version_info_by_model_id(model_id: str) -> dict:
     """
     Fetches version info by model id.
     returns: dict:version_info
@@ -271,7 +272,7 @@ def load_model_info_by_search_term(model_type, search_term):
     return model.load_model_info(model_info_filepath)
 
 
-def get_model_names_by_type_and_filter(model_type:str, metadata_filter:dict) -> list:
+def get_model_names_by_type_and_filter(model_type: str, metadata_filter: dict) -> list:
     """
     get model file names by model type
     parameter: model_type - string
@@ -339,11 +340,11 @@ def is_valid_file(root, filename, no_info_only, empty_info_only):
 
 def get_model_names_by_input(model_type, empty_info_only):
     """ return: list of model filenames with empty civitai info files """
-    return get_model_names_by_type_and_filter(model_type, {"empty_info_only":empty_info_only})
+    return get_model_names_by_type_and_filter(model_type, {"empty_info_only": empty_info_only})
 
 
 # get id from url
-def get_model_id_from_url(url:str, include_model_ver=False) -> str:
+def get_model_id_from_url(url: str, include_model_ver=False) -> str:
     """ return: model_id from civitai url """
     util.printD("Run get_model_id_from_url")
     model_id = None
@@ -390,6 +391,7 @@ def preview_exists(model_path):
 
     return False
 
+
 def get_image_url(img_dict, max_size_preview):
     """
     Create the image download URL
@@ -405,6 +407,7 @@ def get_image_url(img_dict, max_size_preview):
             url = re.sub(r'/width=\d+/', '/width=' + str(width) + '/', url)
 
     return url
+
 
 def verify_preview(path, img_dict, max_size_preview, nsfw_preview_threshold):
     """
@@ -438,7 +441,6 @@ def verify_preview(path, img_dict, max_size_preview, nsfw_preview_threshold):
 
         yield result
 
-
     if not success:
         yield (False, None)
 
@@ -448,7 +450,7 @@ def verify_preview(path, img_dict, max_size_preview, nsfw_preview_threshold):
 
 # get preview image by model path
 # image will be saved to file, so no return
-def get_preview_image_by_model_path(model_path:str, max_size_preview, nsfw_preview_threshold, preferred_preview=None):
+def get_preview_image_by_model_path(model_path: str, max_size_preview, nsfw_preview_threshold, preferred_preview=None):
     """
     Downloads a preview image for a model if one doesn't already exist.
     Skips images that are more NSFW than the user's NSFW threshold
@@ -464,7 +466,7 @@ def get_preview_image_by_model_path(model_path:str, max_size_preview, nsfw_previ
         return
 
     base, _ = os.path.splitext(model_path)
-    preview_path =  f"{base}.preview.png" # TODO png not strictly required
+    preview_path = f"{base}.preview.png"  # TODO png not strictly required
     info_file = f"{base}{SUFFIX}{model.CIVITAI_EXT}"
 
     # need to download preview image
@@ -510,7 +512,7 @@ def get_preview_image_by_model_path(model_path:str, max_size_preview, nsfw_previ
 
     for img_dict in images:
         for result in verify_preview(
-            preview_path, img_dict, max_size_preview, nsfw_preview_threshold
+                preview_path, img_dict, max_size_preview, nsfw_preview_threshold
         ):
             if not isinstance(result, str):
                 success, _ = result
@@ -528,7 +530,7 @@ def get_preview_image_by_model_path(model_path:str, max_size_preview, nsfw_previ
 
 # search local model by version id in 1 folder, no subfolder
 # return - model_info
-def search_local_model_info_by_version_id(folder:str, model_ids:dict) -> dict:
+def search_local_model_info_by_version_id(folder: str, model_ids: dict) -> dict:
     """ Searches a folder for model_info files,
         returns the model_info from a file if its id matches the model id.
     """
@@ -581,7 +583,7 @@ def search_local_model_info_by_version_id(folder:str, model_ids:dict) -> dict:
     return None
 
 
-def get_model_id_from_model_path(model_path:str):
+def get_model_id_from_model_path(model_path: str):
     """ return model_id using model_path """
     # get model info file name
     base, _ = os.path.splitext(model_path)
@@ -601,7 +603,7 @@ def get_model_id_from_model_path(model_path:str):
     return (model_id, local_version_id)
 
 
-def check_model_new_version_by_path(model_path:str, delay:float=0.2) -> tuple:
+def check_model_new_version_by_path(model_path: str, delay: float = 0.2) -> tuple:
     """
     check new version for a model by model path
     return (
@@ -699,7 +701,7 @@ def check_single_model_new_version(root, filename, model_type, delay):
     return request
 
 
-def check_models_new_version_by_model_types(model_types:list, delay:float=0.2) -> list:
+def check_models_new_version_by_model_types(model_types: list, delay: float = 0.2) -> list:
     """
     check all models of model_types for new version
     parameter: delay - float, how many seconds to delay between each request to civitai
@@ -755,20 +757,14 @@ def check_models_new_version_by_model_types(model_types:list, delay:float=0.2) -
 
 
 def move_model_to_subfolder(filepath, model_info):
-    modelid = model_info["modelId"]
+    model_id = model_info["modelId"]
 
-    util.printD(f"Model ID is {modelid}")
-
-    if modelid == "":
+    if model_id == "":
         return None
 
-    content = civitai_get(f'{URLS["modelId"]}{modelid}')
-
-    util.printD(content)
+    content = civitai_get(f'{URLS["modelId"]}{model_id}')
 
     tags = content["tags"]
-
-    util.printD(tags)
 
     # iterate through tags until we find one that matches MODEL_CATEGORIES
 
@@ -777,39 +773,27 @@ def move_model_to_subfolder(filepath, model_info):
             model_category = tag
 
             # create subfolder if it doesn't exist
-            util.printD("Current filepath is " + filepath)
-
             # check to make sure the model is not already in the correct subfolder
             if model_category in filepath:
-                util.printD("Model is already in the correct subfolder")
                 return filepath
 
             # get the file path without the filename
             folderpath = os.path.dirname(filepath)
 
-            util.printD("Current folderpath is " + folderpath)
-
             # create the new folder path
             new_folderpath = os.path.join(folderpath, model_category)
 
-            util.printD("New folderpath is " + new_folderpath)
-
             # create the new folder if it doesn't exist
-            if not os.path.exists(new_folderpath):
+            if not os.path.isdir(new_folderpath):
                 os.makedirs(new_folderpath)
+
+            util.printD(f"Moving model from {filepath} to {new_folderpath}")
 
             # move the file to the new folder
             new_filepath = os.path.join(new_folderpath, os.path.basename(filepath))
-
-            util.printD("New filepath is " + new_filepath)
-
             os.rename(filepath, new_filepath)
 
             return new_filepath
-
-
-            break
-
 
     util.printD("WARNING: Unable to find tag for folder")
 

--- a/ch_lib/model_action_civitai.py
+++ b/ch_lib/model_action_civitai.py
@@ -94,11 +94,9 @@ def scan_single_model(filepath, model_type, refetch_old, organize_models, delay)
             model_info = dummy_model_info(filepath, sha256_hash, model_type)
             yield True
 
-        # if model is lora and not already in a subfolder, move into subfolder based on its type (character, clothing, etc)
-        if organize_models and model_type == "lora":
-            filepath = civitai.move_model_to_subfolder(filepath, model_info)
-
-        if organize_models and model_type == "lycoris":
+        # if model is lora and not already in a subfolder, move into subfolder based on its type (character,
+        # clothing, etc.)
+        if organize_models and model_type in ["lora", "lycoris"]:
             filepath = civitai.move_model_to_subfolder(filepath, model_info)
 
         model.process_model_info(filepath, model_info, model_type, refetch_old=refetch_old)

--- a/ch_lib/model_action_civitai.py
+++ b/ch_lib/model_action_civitai.py
@@ -49,7 +49,7 @@ def get_metadata_skeleton():
     return metadata
 
 
-def scan_single_model(filepath, model_type, refetch_old, delay):
+def scan_single_model(filepath, model_type, refetch_old, organize_models, delay):
     """
     Gets model info for a model by feeding its sha256 hash into civitai's api
 
@@ -92,6 +92,14 @@ def scan_single_model(filepath, model_type, refetch_old, delay):
 
         if not model_info:
             model_info = dummy_model_info(filepath, sha256_hash, model_type)
+            yield True
+
+        # if model is lora and not already in a subfolder, move into subfolder based on its type (character, clothing, etc)
+        if organize_models and model_type == "lora":
+            filepath = civitai.move_model_to_subfolder(filepath, model_info)
+
+        if organize_models and model_type == "lycoris":
+            filepath = civitai.move_model_to_subfolder(filepath, model_info)
 
         model.process_model_info(filepath, model_info, model_type, refetch_old=refetch_old)
 
@@ -104,7 +112,7 @@ def scan_single_model(filepath, model_type, refetch_old, delay):
     yield True
 
 
-def scan_model(scan_model_types, refetch_old, progress=gr.Progress()):
+def scan_model(scan_model_types, refetch_old, organize_models=False, progress=gr.Progress()):
     """ Scan model to generate SHA256, then use this SHA256 to get model info from civitai
         return output msg
     """
@@ -162,7 +170,7 @@ def scan_model(scan_model_types, refetch_old, progress=gr.Progress()):
 
         count[0] = count[0] + 1
 
-        for result in scan_single_model(filepath, model_type, refetch_old, delay):
+        for result in scan_single_model(filepath, model_type, refetch_old, organize_models, delay):
             if isinstance(result, str):
                 progress(tracker, desc=result, unit="models")
                 continue

--- a/ch_lib/sections.py
+++ b/ch_lib/sections.py
@@ -25,15 +25,15 @@ def scan_models_section():
             )
     with gr.Row():
         with gr.Column():
-            refetch_old_ckb = gr.Checkbox(
-                label="Replace Old Metadata Formats*",
-                value=False,
-                elem_id="ch_refetch_old_ckb"
-            )
             organize_models = gr.Checkbox(
                 label="Move models into category folders",
                 value=False,
                 elem_id="organize_models"
+            )
+            refetch_old_ckb = gr.Checkbox(
+                label="Replace Old Metadata Formats*",
+                value=False,
+                elem_id="ch_refetch_old_ckb"
             )
             gr.HTML("""
                 * [<a href=https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper/wiki/Metadata-Format-Changes>wiki</a>] Do not use this option if you have made changes with the metadata editor without backing up your data!!<br><br>

--- a/ch_lib/sections.py
+++ b/ch_lib/sections.py
@@ -30,6 +30,11 @@ def scan_models_section():
                 value=False,
                 elem_id="ch_refetch_old_ckb"
             )
+            organize_models = gr.Checkbox(
+                label="Move models into category folders",
+                value=False,
+                elem_id="organize_models"
+            )
             gr.HTML("""
                 * [<a href=https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper/wiki/Metadata-Format-Changes>wiki</a>] Do not use this option if you have made changes with the metadata editor without backing up your data!!<br><br>
                 """)
@@ -58,7 +63,8 @@ def scan_models_section():
         model_action_civitai.scan_model,
         inputs=[
             scan_model_types_drop,
-            refetch_old_ckb
+            refetch_old_ckb,
+            organize_models
         ],
         outputs=scan_model_log_md
     )


### PR DESCRIPTION
This PR adds the experimental ability to automatically move loras into their respective category subfolders, intended to help users with large lora folders organize their collection.

![image](https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper/assets/3081055/730af4ec-e2dd-4857-b7b8-ec166072b255)

Selecting the "move models" checkbox will cause Civitai Helper to make an additional API call to retrieve the Model's base metadata, including its tags (as these are not included when looking up by hash). If it finds a tag that matches the base "categories" on the model browser (character, style, clothing, poses, etc.), it will move the model into the relevant subfolder. Models already in a matching subfolder or models that have no matching tags will be ignored. In addition, this occurs before model info processing, so thumbnails, example images, and info files will write into the new folder. This has successfully been tested on Lora folders up to 1500 entries, with only 3 not moved due to insufficient metadata.

Please note that right now, this cannot retroactively move models that have existing metadata as it is built into the model scanner, which only runs on models that are missing metadata files. This is primarily a functional proof of concept that I initially built for myself, and I welcome reviews or suggestions on improving this functionality.