### PR TITLE
fix: don't crash if civitai response has no images

### DIFF
--- a/ch_lib/model_action_civitai.py
+++ b/ch_lib/model_action_civitai.py
@@ -447,7 +447,7 @@ def get_model_info_by_id(model_id:str) -> dict:
         filenames.append(filename)
         version_strs.append(version_str)
         base_models.append(version.get("baseModel", None))
-        previews[version_str] = version["images"]
+        previews[version_str]: list = version.get("images", [])
 
     # get folder by model type
     folder = model.folders[model_type]


### PR DESCRIPTION
If Civitai responds to a model search (like via get_model_info_by_id), the response may not always include an "images" key in the data for the returned models. When that happens, the old code would raise a KeyError here. It is not clear to me why Civitai only sometimes includes images, but at the time of this writing, this behavior is consistently reproducible by trying to retrieve the model from this URL: https://civitai.com/models/350450/sdxl-lightning-loras

This change gracefully returns an empty list if the key is missing. This change seems to work fine with the rest of the extension in the A1111 UI.