### PR TITLE
fix breaking changes introduced by gradio 4

### DIFF
--- a/browser/browser.py
+++ b/browser/browser.py
@@ -96,8 +96,8 @@ def make_ui():
         return [
             state,
             container.safe_substitute({"cards": "".join(cards)}),
-            ch_prev_btn.update(interactive=state["current_page"] > 0),
-            ch_next_btn.update(interactive=next_page is not None)
+            gr.Button(interactive=state["current_page"] > 0),  # Enable/disable buttons
+            gr.Button(interactive=next_page is not None)
         ]
 
     with gr.Row():
@@ -106,17 +106,14 @@ def make_ui():
     with gr.Row(equal_height=True):
         ch_query_txt = gr.Textbox(
             label="Query",
-            lines=1,
             value=""
         )
         ch_tag_txt = gr.Textbox(
             label="Tag",
-            lines=1,
             value=""
         )
         ch_age_drop = gr.Dropdown(
             label="Model Age",
-            lines=1,
             value="AllTime",
             choices=[
                 "AllTime",
@@ -128,7 +125,6 @@ def make_ui():
         )
         ch_sort_drop = gr.Dropdown(
             label="Model Age",
-            lines=1,
             value="Newest",
             choices=[
                 "Highest Rated",
@@ -140,7 +136,6 @@ def make_ui():
     with gr.Row(equal_height=True):
         ch_base_model_drop = gr.Dropdown(
             label="Base Model",
-            lines=1,
             value=None,
             multiselect=True,
             choices=[
@@ -169,7 +164,6 @@ def make_ui():
         )
         ch_type_drop = gr.Dropdown(
             label="Model Type",
-            lines=1,
             value=None,
             multiselect=True,
             choices=[
@@ -194,24 +188,20 @@ def make_ui():
         ch_nsfw_ckb = gr.Checkbox(
             label="Allow NSFW Models",
             value=util.get_opts("ch_nsfw_threshold") != "PG",
-            lines=1
         )
 
         ch_search_btn = gr.Button(
             variant="primary",
             value="Search",
-            lines=1
         )
 
     with gr.Row(equal_height=True):
         ch_prev_btn = gr.Button(
             value="Previous Page",
-            lines=1,
             interactive=False
         )
         ch_next_btn = gr.Button(
             value="Next Page",
-            lines=1,
             interactive=False
         )
 

--- a/ch_lib/sections.py
+++ b/ch_lib/sections.py
@@ -73,7 +73,7 @@ def get_model_info_by_url_section():
 
     def get_model_names_by_input(model_type, empty_info_only):
         names = civitai.get_model_names_by_input(model_type, empty_info_only)
-        return model_name_drop.update(choices=names)
+        return gr.Dropdown(choices=names)
 
     no_info_model_names = civitai.get_model_names_by_input("ckp", False)
 
@@ -252,15 +252,15 @@ def download_section():
 
         return [
             state, data["model_name"], data["model_type"],
-            dl_subfolder_drop.update(
+            gr.Dropdown(
                 choices=subfolders,
                 value=subfolder
             ),
-            dl_version_drop.update(
+            gr.Dropdown(
                 choices=version_strs,
                 value=version_strs[0]
             ),
-            files_row.update(
+            gr.Column(
                 visible=True
             )
         ]
@@ -306,27 +306,27 @@ def download_section():
                 else:
                     raise ValueError(f"Invalid filedata: {filedata}")
 
-            output_add.append(elems["txtbx"].update(value=filename))
-            output_add.append(elems["row"].update(visible=visible))
+            output_add.append(gr.Textbox(value=filename))
+            output_add.append(gr.Row(visible=visible))
 
         return [
             state,
-            dl_filename_txtbox.update(
+            gr.Textbox(
                 value=base
             ),
-            dl_extension_txtbox.update(
+            gr.Textbox(
                 value=ext
             ),
-            dl_preview_img.update(
+            gr.Gallery(
                 value=previews
             ),
-            dl_preview_url.update(
+            gr.Textbox(
                 value=preview
             ),
-            download_all_row.update(
+            gr.Checkbox(
                 visible=(state["files_count"][dl_version] > 1)
             ),
-            dl_base_model_txtbox.update(
+            gr.Textbox( 
                 value=base_model
             )
         ] + output_add
@@ -345,7 +345,7 @@ def download_section():
     def update_dl_preview_url(state, dl_preview_index):
         preview_url = state["filtered_previews"][dl_preview_index]
 
-        return dl_preview_url.update(
+        return gr.Checkbox(
             value=preview_url
         )
 
@@ -353,7 +353,7 @@ def download_section():
         # For some reason, you can't pass gr.SelectData and
         # inputs at the same time. :/
 
-        return dl_preview_index.update(
+        return gr.Number(
             value=evt.index
         )
 

--- a/style.css
+++ b/style.css
@@ -345,6 +345,6 @@ blockquote ol {
 }
 #ch_model_search_results {
     max-height: 85vh; /* maybe try to figure out a way to fill the whole screen unless it's under a certain resolution? */
-    overflow: scroll;
+    overflow: scroll !important;
 }
 /* End of Civitai Helper Browser */


### PR DESCRIPTION
After the lastest big SD Forge update this extension stopped working because they moved from gradio 3 to 4. Pretty much all that needed to be done was to move from the deprecated .update() method of components as per https://github.com/gradio-app/gradio/issues/6339.

This should fix #121 (and also https://github.com/butaixianran/Stable-Diffusion-Webui-Civitai-Helper/issues/300 in the original repo). I haven't had a chance to test it profusely yet, but fetching models, selecting and downloading works now. 

Honestly, this is the first time I've ever seen gradio so I have no idea if this will break the extension for WebUIs that use Gradio 3, but since update() was marked as deprecated I assume the new approach should be working for older installations too. 

I've also added !important to fix scrollbar in the browser, idk why, but it got overrriden by element style.