### PR TITLE
add a simple form for adding new lines to batch list

### DIFF
--- a/ch_lib/sections.py
+++ b/ch_lib/sections.py
@@ -913,7 +913,7 @@ def download_multiple_section():
                         lines=1,
                         max_lines=1,
                         value="",
-                        placeholder="Model URL or Model ID",
+                        placeholder="Model URL",
                         elem_id="ch_dl_url"
                     )
                 with gr.Column(elem_classes="justify-bottom"):


### PR DESCRIPTION
Implemented #136 

This PR adds a simple form to the Batch Download tab, which allows the user to add lines to the URL list, while being able to easily set all the (currenty supported) parameters.


![image](https://github.com/user-attachments/assets/147f8292-1946-45e4-a7c1-537f91f7c9df)
