### PR TITLE
Automatically add Civitai resource metadata to generated images

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you just want to download the models into the appropriate directories yoursel
 In the same place you can scan a model, you can also scan the model info and the extension will attempt to fill in any missing information from the images themselves. This is a very hit-or-miss process, but if you are trying to get the prompt from an image  the "preview image prompt" button and it fails to work, performing this scan may retrieve the information necessary to fix it.
 
 ### Automatic Generated Image Metadata
-Automatically adds metadata to any image you generate using the data from `[model_name].civitai.info`. The metadata added closely matches images generated on Civitai's on-site generator. This will make the website automatically detect and link all resources used. With this feature added, this extension now supercedes the official Civitai extension which is no longer actively maintained.
+Automatically adds metadata to any image you generate using the data from `[model_name].civitai.info`. The metadata added closely matches images generated on Civitai's on-site generator. This will make the website automatically detect and link all resources used.
 Just make sure you scan after downloading any new models.
 
 For the on-site detector to work correctly, you will need to disable the default added resource hashes.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Civitai: ![Civitai Url](https://civitai.com/models/16768/civitai-helper-sd-webui
   - ❌: Remove/Delete model
 * Option to always show additional buttons, to help with touchscreens.
 * To the best of my knowledge, this extension should still work in versions of webui prior to v1.5.0, but it is not tested. I make best-effort attempts to write code that *should* maintain compatibility with older versions, but if you have run into problems, please file an issue and I'll attempt to resolve it.
+* **New feature**: Automatically add metadata of model resources used to all generated images. Useful for uploading to Civitai. More information below.
 
 # Install
 Go to SD webui's extension tab, go to `Install from url` sub-tab.
@@ -83,6 +84,20 @@ If you just want to download the models into the appropriate directories yoursel
 
 ### Update Image Generation Information
 In the same place you can scan a model, you can also scan the model info and the extension will attempt to fill in any missing information from the images themselves. This is a very hit-or-miss process, but if you are trying to get the prompt from an image  the "preview image prompt" button and it fails to work, performing this scan may retrieve the information necessary to fix it.
+
+### Automatic Generated Image Metadata
+Automatically adds metadata to any image you generate using the data from `[model_name].civitai.info`. The metadata added closely matches images generated on Civitai's on-site generator. This will make the website automatically detect and link all resources used. With this feature added, this extension now supercedes the official Civitai extension which is no longer actively maintained.
+Just make sure you scan after downloading any new models.
+
+For the on-site detector to work correctly, you will need to disable the default added resource hashes.
+
+**Disable the following settings:**
+* Stable Diffusion -> Extra Networks -> Add Textual Inversion hashes to infotext
+* Stable Diffusion -> Extra Networks -> Add Lora hashes to infotext
+* User Interface -> Infotext -> Add model hash to infotext
+* User Interface -> Infotext -> Add VAE hash to infotext
+
+The above settings must be disabled so the Civitai site does not get confused with incorrect hashes.
 
 ## Model Card
 

--- a/scripts/civitai_helper.py
+++ b/scripts/civitai_helper.py
@@ -342,6 +342,15 @@ def on_ui_settings():
             {"interactive": True},
             section=section)
     )
+    shared.opts.add_option(
+        "ch_image_metadata",
+        shared.OptionInfo(
+            True,
+            "Automatically add resource metadata to all generated images",
+            gr.Checkbox,
+            {"interactive": True},
+            section=section)
+    )
     shared.opts.onchange(
         "ch_proxy",
         update_proxy

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -52,15 +52,16 @@ def add_resource_metadata(params):
     if isinstance(sd_processing, processing.StableDiffusionProcessingTxt2Img) and sd_processing.enable_hr:
         if sd_processing.hr_checkpoint_name is not None and sd_processing.hr_checkpoint_info.name_for_extra != sd_processing.sd_model_name:
             add_civitai_resource(Path(sd_processing.hr_checkpoint_info.filename).absolute())
-        prompt_list = [[sd_processing.hr_prompt, sd_processing.hr_second_pass_steps, True], [sd_processing.hr_negative_prompt, sd_processing.hr_second_pass_steps, False]] + prompt_list
-        extra_network_data = list(sd_processing.hr_extra_network_data.values()) + list(extra_network_data)
+        prompt_list += [[sd_processing.hr_prompt, sd_processing.hr_second_pass_steps, True], [sd_processing.hr_negative_prompt, sd_processing.hr_second_pass_steps, False]]
+        extra_network_data = list(extra_network_data) + list(sd_processing.hr_extra_network_data.values())
 
     # Collect lora weights, skip duplicates
     extra_network_weights = {}
     for extra_network_params in reduce(lambda list1, list2: list1 + list2, extra_network_data):
         extra_network_name = extra_network_params.positional[0]
         te_multiplier = float(extra_network_params.positional[1]) if len(extra_network_params.positional) > 1 else 1.0
-        extra_network_weights[extra_network_name] = te_multiplier
+        if extra_network_name not in extra_network_weights:
+            extra_network_weights[extra_network_name] = te_multiplier
 
     # Add lora metadata
     for extra_network_name, te_multiplier in extra_network_weights.items():

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from functools import reduce
 
 from ch_lib import util
-from modules import script_callbacks, extra_networks, prompt_parser
+from modules import script_callbacks, extra_networks, prompt_parser, processing, sd_models
 import networks
 from backend.args import dynamic_args
+import modules.processing_scripts.comments as comments
 
 def add_resource_metadata(params):
     if not util.get_opts("ch_image_metadata") or 'parameters' not in params.pnginfo:
@@ -15,17 +16,8 @@ def add_resource_metadata(params):
 
     # StableDiffusionProcessing
     sd_processing = params.p
-
-    # Get embedding file paths
-    embed_filepaths = {}
-    try:
-        for dirpath, dirnames, filenames in os.walk(dynamic_args['embedding_dir'], followlinks=True):
-            for filename in filenames:
-                filepath = Path(dirpath) / filename
-                if filepath.stat().st_size != 0 and filepath.suffix.upper() in ['.BIN', '.PT', '.SAFETENSORS']:
-                    embed_filepaths[filepath.stem.strip().lower()] = filepath.absolute()
-    except Exception as e:
-        util.printD(f"Embedding directory error: {e}")
+    # CheckpointInfo
+    sd_checkpoint_info = sd_models.get_closet_checkpoint_match(sd_processing.sd_model_name)
 
     civitai_resource_list = []
 
@@ -51,27 +43,56 @@ def add_resource_metadata(params):
             util.printD(f"Civitai info error: {e}")
 
     # Add checkpoint metadata
-    add_civitai_resource(Path(sd_processing.sd_model.sd_checkpoint_info.filename).absolute())
+    add_civitai_resource(Path(sd_checkpoint_info.filename).absolute())
 
-    # Add extra network metadata (lora/lycoris/locon/etc.)
-    for item in networks.loaded_networks:
-        extra_network_params = next(x.positional for value in sd_processing.extra_network_data.values() for x in value if x.positional[0] == item.name)
-        te_multiplier = float(extra_network_params[1]) if len(extra_network_params) > 1 else 1.0
-        add_civitai_resource(Path(item.network_on_disk.filename).absolute(), te_multiplier)
+    prompt_list = [[sd_processing.prompt, sd_processing.steps, True], [sd_processing.negative_prompt, sd_processing.steps, False]]
+    extra_network_data = sd_processing.extra_network_data.values()
+
+    # Add hires. fix data
+    if isinstance(sd_processing, processing.StableDiffusionProcessingTxt2Img) and sd_processing.enable_hr:
+        if sd_processing.hr_checkpoint_name is not None and sd_processing.hr_checkpoint_info.name_for_extra != sd_processing.sd_model_name:
+            add_civitai_resource(Path(sd_processing.hr_checkpoint_info.filename).absolute())
+        prompt_list = [[sd_processing.hr_prompt, sd_processing.hr_second_pass_steps, True], [sd_processing.hr_negative_prompt, sd_processing.hr_second_pass_steps, False]] + prompt_list
+        extra_network_data = list(sd_processing.hr_extra_network_data.values()) + list(extra_network_data)
+
+    # Collect lora weights, skip duplicates
+    extra_network_weights = {}
+    for extra_network_params in reduce(lambda list1, list2: list1 + list2, extra_network_data):
+        extra_network_name = extra_network_params.positional[0]
+        te_multiplier = float(extra_network_params.positional[1]) if len(extra_network_params.positional) > 1 else 1.0
+        extra_network_weights[extra_network_name] = te_multiplier
+
+    # Add lora metadata
+    for extra_network_name, te_multiplier in extra_network_weights.items():
+        network_on_disk = networks.available_network_aliases.get(extra_network_name, None)
+        add_civitai_resource(Path(network_on_disk.filename).absolute(), te_multiplier)
+
+    # Get embedding file paths
+    embed_filepaths = {}
+    try:
+        for dirpath, dirnames, filenames in os.walk(dynamic_args['embedding_dir'], followlinks=True):
+            for filename in filenames:
+                filepath = Path(dirpath) / filename
+                if filepath.stat().st_size != 0 and filepath.suffix.upper() in ['.BIN', '.PT', '.SAFETENSORS']:
+                    embed_filepaths[filepath.stem.strip().lower()] = filepath.absolute()
+    except Exception as e:
+        util.printD(f"Embedding directory error: {e}")
 
     # Add textual inversion embed metadata
     if len(embed_filepaths) > 0:
         embed_weights = {}
         try:
             embed_regex = re.compile(r"(?:^|[\s,])(" + '|'.join(re.escape(embed_name) for embed_name in embed_filepaths.keys()) + r")(?:$|[\s,])", re.IGNORECASE | re.MULTILINE)
-            for prompt, is_positive in [[sd_processing.prompt, True], [sd_processing.negative_prompt, False]]:
+            
+            for prompt, steps, is_positive in prompt_list:
                 # parse all special prompt rules
-                extra_networks_stripped, _ = extra_networks.parse_prompt(prompt)
+                comments_stripped = comments.strip_comments(prompt).strip()
+                extra_networks_stripped, _ = extra_networks.parse_prompt(comments_stripped)
                 if is_positive:
                     _, prompt_flat_list, _ = prompt_parser.get_multicond_prompt_list([extra_networks_stripped])
                 else:
                     prompt_flat_list = [extra_networks_stripped]
-                prompt_edit_schedule = prompt_parser.get_learned_conditioning_prompt_schedules(prompt_flat_list, sd_processing.steps)
+                prompt_edit_schedule = prompt_parser.get_learned_conditioning_prompt_schedules(prompt_flat_list, steps)
                 prompts = [text for step, text in reduce(lambda list1, list2: list1 + list2, prompt_edit_schedule)]
                 for scheduled_prompt in prompts:
                     # calculate attention weights

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -1,0 +1,72 @@
+import json
+import re
+import os
+from pathlib import Path
+
+from ch_lib import util
+from modules import script_callbacks, extra_networks, prompt_parser
+import networks
+from backend.args import dynamic_args
+
+def add_resource_metadata(params):
+    if 'parameters' not in params.pnginfo: return
+
+    # StableDiffusionProcessing
+    sd_processing = params.p
+
+    # Get embedding file paths
+    embed_filepaths = {}
+    try:
+        for dirpath, dirnames, filenames in os.walk(dynamic_args['embedding_dir'], followlinks=True):
+            for filename in filenames:
+                filepath = Path(dirpath) / filename
+                if filepath.stat().st_size != 0 and filepath.suffix.upper() in ['.BIN', '.PT', '.SAFETENSORS']:
+                    embed_filepaths[filepath.stem.strip().lower()] = filepath.absolute()
+    except Exception as e:
+        util.printD(f"Embedding directory error: {e}")
+
+    civitai_resource_list = []
+
+    def add_civitai_resource(base_file_path, weight=None, type_name=None):
+        try:
+            # Read civitai metadata from previously generated info file
+            file_path = Path(base_file_path).with_suffix(".civitai.info")
+            with open(file_path, 'r') as file:
+                civitai_info = json.load(file)
+                resource_data = {}
+                resource_data["type"] = type_name if type_name is not None else civitai_info["model"]["type"].lower()
+                if resource_data["type"] in ["locon", "loha"]:
+                    resource_data["type"] = "lycoris"
+                if weight is not None:
+                    resource_data["weight"] = weight
+                resource_data["modelVersionId"] = civitai_info["id"]
+                resource_data["modelName"] = civitai_info["model"]["name"]
+                resource_data["modelVersionName"] = civitai_info["name"]
+                civitai_resource_list.append(resource_data)
+        except FileNotFoundError:
+            util.printD(f"Warning: '{file_path}' not found. Did you forget to scan?")
+        except Exception as e:
+            util.printD(f"Civitai info error: {e}")
+
+    # Add checkpoint metadata
+    add_civitai_resource(Path(sd_processing.sd_model.sd_checkpoint_info.filename).absolute())
+
+    # Add extra network metadata (lora/lycoris/locon/etc.)
+    for item in networks.loaded_networks:
+        extra_network_params = next(x.positional for value in sd_processing.extra_network_data.values() for x in value if x.positional[0] == item.name)
+        te_multiplier = float(extra_network_params[1]) if len(extra_network_params) > 1 else 1.0
+        add_civitai_resource(Path(item.network_on_disk.filename).absolute(), te_multiplier)
+
+    # Add textual inversion embed metadata
+    if len(embed_filepaths) > 0:
+        embed_regex = re.compile(r"(?:^|[\s,])(" + '|'.join(re.escape(embed_name) for embed_name in embed_filepaths.keys()) + r")(?:$|[\s,])", re.IGNORECASE | re.MULTILINE)
+        for prompt in [sd_processing.prompt, sd_processing.negative_prompt]:
+            # strip lora definitions, calculate attention weights
+            for text, weight in prompt_parser.parse_prompt_attention(extra_networks.parse_prompt(prompt)[0]):
+                for match in embed_regex.findall(text):
+                    add_civitai_resource(embed_filepaths[match.lower()], weight, "embed")
+
+    if len(civitai_resource_list) > 0:
+        params.pnginfo['parameters'] += f", Civitai resources: {json.dumps(civitai_resource_list, separators=(',', ':'))}"
+
+script_callbacks.on_before_image_saved(add_resource_metadata)

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -12,7 +12,7 @@ import modules.processing_scripts.comments as comments
 
 re_prompt = re.compile(r"^(?!.+\sneg(?:ative)?)(.+\s)prompt(\s\S+)?$")
 re_negative_prompt = re.compile(r"^(.+\s)neg(?:ative)?\sprompt(\s\S+)?$")
-re_checkpoint = re.compile(r"\scheckpoint(?:\s\S+)?$")
+re_checkpoint = re.compile(r"^(?!Hires).+\scheckpoint(?:\s\S+)?$")
 
 def add_resource_metadata(params):
     if not util.get_opts("ch_image_metadata") or 'parameters' not in params.pnginfo:

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -9,7 +9,8 @@ import networks
 from backend.args import dynamic_args
 
 def add_resource_metadata(params):
-    if 'parameters' not in params.pnginfo: return
+    if not util.get_opts("ch_image_metadata") or 'parameters' not in params.pnginfo:
+        return
 
     # StableDiffusionProcessing
     sd_processing = params.p

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -64,11 +64,14 @@ def add_resource_metadata(params):
         embed_weights = {}
         try:
             embed_regex = re.compile(r"(?:^|[\s,])(" + '|'.join(re.escape(embed_name) for embed_name in embed_filepaths.keys()) + r")(?:$|[\s,])", re.IGNORECASE | re.MULTILINE)
-            for prompt in [sd_processing.prompt, sd_processing.negative_prompt]:
+            for prompt, is_positive in [[sd_processing.prompt, True], [sd_processing.negative_prompt, False]]:
                 # parse all special prompt rules
                 extra_networks_stripped, _ = extra_networks.parse_prompt(prompt)
-                _, cond_rules_applied, _ = prompt_parser.get_multicond_prompt_list([extra_networks_stripped])
-                prompt_edit_schedule = prompt_parser.get_learned_conditioning_prompt_schedules(cond_rules_applied, sd_processing.steps)
+                if is_positive:
+                    _, prompt_flat_list, _ = prompt_parser.get_multicond_prompt_list([extra_networks_stripped])
+                else:
+                    prompt_flat_list = [extra_networks_stripped]
+                prompt_edit_schedule = prompt_parser.get_learned_conditioning_prompt_schedules(prompt_flat_list, sd_processing.steps)
                 prompts = [text for step, text in reduce(lambda list1, list2: list1 + list2, prompt_edit_schedule)]
                 for scheduled_prompt in prompts:
                     # calculate attention weights

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -124,7 +124,7 @@ def add_resource_metadata(params):
     if len(embed_filepaths) > 0:
         embed_weights = {}
         try:
-            embed_regex = re.compile(r"(?:^|[\s,])(" + '|'.join(re.escape(embed_name) for embed_name in embed_filepaths.keys()) + r")(?:$|[\s,])", re.IGNORECASE | re.MULTILINE)
+            embed_regex = re.compile(r"(?:^|[\s,.])(" + '|'.join(re.escape(embed_name) for embed_name in embed_filepaths.keys()) + r")(?:$|[\s,.])", re.IGNORECASE | re.MULTILINE)
             
             for prompt, steps, is_positive in prompt_list:
                 # parse all special prompt rules

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -2,6 +2,7 @@ import json
 import re
 import os
 from pathlib import Path
+from functools import reduce
 
 from ch_lib import util
 from modules import script_callbacks, extra_networks, prompt_parser
@@ -60,12 +61,27 @@ def add_resource_metadata(params):
 
     # Add textual inversion embed metadata
     if len(embed_filepaths) > 0:
-        embed_regex = re.compile(r"(?:^|[\s,])(" + '|'.join(re.escape(embed_name) for embed_name in embed_filepaths.keys()) + r")(?:$|[\s,])", re.IGNORECASE | re.MULTILINE)
-        for prompt in [sd_processing.prompt, sd_processing.negative_prompt]:
-            # strip lora definitions, calculate attention weights
-            for text, weight in prompt_parser.parse_prompt_attention(extra_networks.parse_prompt(prompt)[0]):
-                for match in embed_regex.findall(text):
-                    add_civitai_resource(embed_filepaths[match.lower()], weight, "embed")
+        embed_weights = {}
+        try:
+            embed_regex = re.compile(r"(?:^|[\s,])(" + '|'.join(re.escape(embed_name) for embed_name in embed_filepaths.keys()) + r")(?:$|[\s,])", re.IGNORECASE | re.MULTILINE)
+            for prompt in [sd_processing.prompt, sd_processing.negative_prompt]:
+                # parse all special prompt rules
+                extra_networks_stripped, _ = extra_networks.parse_prompt(prompt)
+                _, cond_rules_applied, _ = prompt_parser.get_multicond_prompt_list([extra_networks_stripped])
+                prompt_edit_schedule = prompt_parser.get_learned_conditioning_prompt_schedules(cond_rules_applied, sd_processing.steps)
+                prompts = [text for step, text in reduce(lambda list1, list2: list1 + list2, prompt_edit_schedule)]
+                for scheduled_prompt in prompts:
+                    # calculate attention weights
+                    for text, weight in prompt_parser.parse_prompt_attention(scheduled_prompt):
+                        for match in embed_regex.findall(text):
+                            # store final weight of embedding in dictionary
+                            embed_weights[match.lower()] = weight
+        except Exception as e:
+            util.printD(f"Error parsing prompt for embeddings: {e}")
+
+        # add final weights for embeddings
+        for embed_name, weight in embed_weights.items():
+            add_civitai_resource(embed_filepaths[embed_name], weight, "embed")
 
     if len(civitai_resource_list) > 0:
         params.pnginfo['parameters'] += f", Civitai resources: {json.dumps(civitai_resource_list, separators=(',', ':'))}"

--- a/scripts/image_metadata.py
+++ b/scripts/image_metadata.py
@@ -57,11 +57,12 @@ def add_resource_metadata(params):
 
     # Collect lora weights, skip duplicates
     extra_network_weights = {}
-    for extra_network_params in reduce(lambda list1, list2: list1 + list2, extra_network_data):
-        extra_network_name = extra_network_params.positional[0]
-        te_multiplier = float(extra_network_params.positional[1]) if len(extra_network_params.positional) > 1 else 1.0
-        if extra_network_name not in extra_network_weights:
-            extra_network_weights[extra_network_name] = te_multiplier
+    if isinstance(extra_network_data, list) and len(extra_network_data) > 0 or not isinstance(extra_network_data, list) and any(extra_network_data):
+        for extra_network_params in reduce(lambda list1, list2: list1 + list2, extra_network_data):
+            extra_network_name = extra_network_params.positional[0]
+            te_multiplier = float(extra_network_params.positional[1]) if len(extra_network_params.positional) > 1 else 1.0
+            if extra_network_name not in extra_network_weights:
+                extra_network_weights[extra_network_name] = te_multiplier
 
     # Add lora metadata
     for extra_network_name, te_multiplier in extra_network_weights.items():


### PR DESCRIPTION
This adds a new feature which makes any generated image automatically add resource metadata in the format of images generated with the Civitai on-site generator.

Since the official Civitai extension is a dead project, a new way to add metadata to images is needed.
And since this extension does everything that extension did but better, it made sense to add this feature as well.

I tried to implement it as concisely as possible, reusing as much of the existing codebase as I could.
It should be very simple to understand, robust, and easy to maintain. (Could probably be optimized.)

I also updated the readme to explain the feature. I'm not sure how to update the other languages.

And I added a checkbox to disable/enable the feature in the extension settings.

I have tested this on the latest version of forge. I cannot guarantee this will work in older versions.

Thanks to all contributors for making this wonderful extension! It makes using the web UI with a huge amount of different resources so simple and easy.