### PR TITLE
Update model.py to fix option to save lycoris models in lora location

### DIFF
--- a/ch_lib/model.py
+++ b/ch_lib/model.py
@@ -118,22 +118,22 @@ def get_custom_model_folder():
 
     if util.get_opts("ch_dl_lyco_to_lora"):
         folders["lycoris"] = folders["lora"]
-
-    try:
-        # pre-1.5.0
-        if os.path.isdir(shared.cmd_opts.lyco_dir):
-            folders["lycoris"] = shared.cmd_opts.lyco_dir
-
-    except AttributeError:
+    else:
         try:
-            # sd-webui v1.5.1 added a backcompat option for lyco.
-            if os.path.isdir(shared.cmd_opts.lyco_dir_backcompat):
-                folders["lycoris"] = shared.cmd_opts.lyco_dir_backcompat
-
+            # pre-1.5.0
+            if os.path.isdir(shared.cmd_opts.lyco_dir):
+                folders["lycoris"] = shared.cmd_opts.lyco_dir
+    
         except AttributeError:
-            # v1.5.0 has no options for the Lyco dir:
-            # it is hardcoded as 'os.path.join(paths.models_path, "LyCORIS")'
-            return
+            try:
+                # sd-webui v1.5.1 added a backcompat option for lyco.
+                if os.path.isdir(shared.cmd_opts.lyco_dir_backcompat):
+                    folders["lycoris"] = shared.cmd_opts.lyco_dir_backcompat
+    
+            except AttributeError:
+                # v1.5.0 has no options for the Lyco dir:
+                # it is hardcoded as 'os.path.join(paths.models_path, "LyCORIS")'
+                return
 
 
 def locate_model_from_partial(root, model_name):


### PR DESCRIPTION
There was a missing "else" after the check to see if the option to save lycoris models in lora location was enabled.  This meant that even if the option was enabled, the lycoris folder would get overwritten with one of the standard folders after, so the option wouldn't work.